### PR TITLE
use tidyverse to replace reshape2:melt

### DIFF
--- a/gallery.Rmd
+++ b/gallery.Rmd
@@ -711,11 +711,11 @@ demo("volcano", package = "MSG")
 
 gv <- as.data.frame(volcano) %>% 
   rowid_to_column("north") %>% 
-  pivot_longer(-north) %>% 
-  mutate(
-    west = str_replace_all(name, "V", "") %>% as.numeric() %>% `*`(10),
-    north = north * 10
+  pivot_longer(-north, 
+    names_to = "west", names_prefix = "V", 
+    names_ptypes = list(west = integer())
   ) %>% 
+  mutate(north = north * 10, west = west * 10) %>% 
   ggplot(aes(x = north, y = west, z = value, fill = value)) + 
   geom_tile() + 
   scale_fill_distiller(palette = "RdYlGn") +

--- a/gallery.Rmd
+++ b/gallery.Rmd
@@ -377,8 +377,9 @@ coef(summary(lm(V2 ~ V1, BinormCircle)))
 assocplot(x)
 chisq.test(x)$p.value # 卡方检验P值
 
-reshape2::melt(unclass(chisq.test(x)$res), value.name = "residuals") %>% 
-  ggplot(aes(x = Hair, y = Eye)) +
+chisq.test(x)$res %>% 
+  as.data.frame(responseName = "residuals") %>% 
+  ggplot(aes(Hair, Eye)) + 
     geom_tile(aes(fill = residuals)) +
     scale_fill_gradient2()
 ```
@@ -708,12 +709,16 @@ Plot），与等高图的原理完全类似，只是颜色等高图用不同颜�
 ```{r filled-contour,fig.height=4.3,fig.width=7,results="hide",fig.cap="(ref:fig-filled-contour)",fig.scap="(ref:fig-filled-contour-s)", fig.show = 'hold'}
 demo("volcano", package = "MSG")
 
-gv <- volcano %>% 
-  reshape2::melt() %>% 
-  mutate(x = Var1 * 10, y = Var2 * 10) %>% 
-  ggplot(aes(x = x, y = y, z = value, fill = value)) + 
+gv <- as.data.frame(volcano) %>% 
+  rowid_to_column("north") %>% 
+  pivot_longer(-north) %>% 
+  mutate(
+    west = str_replace_all(name, "V", "") %>% as.numeric() %>% `*`(10),
+    north = north * 10
+  ) %>% 
+  ggplot(aes(x = north, y = west, z = value, fill = value)) + 
   geom_tile() + 
-  scale_fill_distiller(palette="RdYlGn") +
+  scale_fill_distiller(palette = "RdYlGn") +
   theme_bw() +
   labs(x = 'Meters North', y = 'Meters West', fill = 'Height\n(meters)')
 gv


### PR DESCRIPTION
reshape2应该不属于tidyverse系列的包。正如tidyr文档中所说，尽管tidyr的目的是为了把数据整理成tidy格式的，而不是通常说的数据重塑（reshape2），其实tidyr实际上reshape2的替代品。

> tidyr replaces reshape2 (2010-2014) and reshape (2005-2010). Somewhat counterintuitively, each iteration of the package has done less. tidyr is designed specifically for tidying data, not general reshaping (reshape2), or the general aggregation (reshape).

此外通过github查看reshape的开发情况来看，[最近一次提交是2017年12月份](https://github.com/hadley/reshape)，所以我还是建议不使用`reshape2::melt`。目前我的水平画图1.15的时候，代码更多更复杂了，期待后续更简单的代码。